### PR TITLE
Bugfix: In der Detailansicht werden die Namen der Vortragenden nicht angezeigt

### DIFF
--- a/src/nerd/tuxmobil/fahrplan/congress/EventDetail.java
+++ b/src/nerd/tuxmobil/fahrplan/congress/EventDetail.java
@@ -26,7 +26,7 @@ public class EventDetail extends SherlockFragmentActivity {
 			args.putString("subtitle", intent.getStringExtra("subtitle"));
 			args.putString("abstract", intent.getStringExtra("abstract"));
 			args.putString("descr", intent.getStringExtra("descr"));
-			args.putString("spkr", intent.getStringExtra("skpr"));
+			args.putString("spkr", intent.getStringExtra("spkr"));
 			args.putString("links", intent.getStringExtra("links"));
 			args.putString("eventid", intent.getStringExtra("eventid"));
 			args.putInt("time", intent.getIntExtra("time", 0));


### PR DESCRIPTION
Hi,

in der Standalone-Version der Detailansicht werden die Namen der Vortragenden aufgrund eines Typos (spkr != skpr) nicht angezeigt. Habe das gefixt.

Grüße
Flo
