### PR TITLE
Display alarms information if there is no alarm entry.

### DIFF
--- a/res/layout/alarms.xml
+++ b/res/layout/alarms.xml
@@ -2,6 +2,7 @@
 <LinearLayout 
 	android:layout_width="fill_parent" android:layout_height="fill_parent"
 	xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
 	android:background="@color/fahrplan_background">
 
 	<ListView
@@ -11,6 +12,8 @@
 	    android:paddingLeft="16dp"
 	    android:paddingRight="16dp"
 	    android:scrollbarStyle="outsideOverlay" >
+    </ListView>
 
-</ListView>
+    <include layout="@layout/alarms_empty" />
+
 </LinearLayout>

--- a/res/layout/alarms_empty.xml
+++ b/res/layout/alarms_empty.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <TextView
+        android:id="@android:id/empty"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_margin="64dp"
+        android:gravity="center"
+        android:text="@string/alarms_empty" />
+
+</merge>

--- a/res/layout/alarms_land_large.xml
+++ b/res/layout/alarms_land_large.xml
@@ -2,6 +2,7 @@
 <LinearLayout 
 	android:layout_width="fill_parent" android:layout_height="fill_parent"
 	xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
 	android:background="@color/fahrplan_background">
 
 	<ListView
@@ -11,6 +12,8 @@
 	    android:paddingLeft="64dp"
 	    android:paddingRight="64dp"
 	    android:scrollbarStyle="outsideOverlay" >
+    </ListView>
 
-</ListView>
+    <include layout="@layout/alarms_empty" />
+
 </LinearLayout>

--- a/res/layout/alarms_large.xml
+++ b/res/layout/alarms_large.xml
@@ -2,6 +2,7 @@
 <LinearLayout 
 	android:layout_width="fill_parent" android:layout_height="fill_parent"
 	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:orientation="vertical"
 	android:background="@color/fahrplan_background">
 
 	<ListView
@@ -11,6 +12,8 @@
 	    android:paddingLeft="48dp"
 	    android:paddingRight="48dp"
 	    android:scrollbarStyle="outsideOverlay" >
+	</ListView>
 
-</ListView>
+	<include layout="@layout/alarms_empty" />
+
 </LinearLayout>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -63,4 +63,9 @@
 	<string name="pref_auto_download">Automatische Updates</string>
 	<string name="parsing_error_generic">Unbekannter Fehler beim Parsen des Fahrplans</string>
 	<string name="parsing_error_with_version">Fehler beim Parsen der Fahrplan-Version %s</string>
+	<string name="alarms_empty">
+		Aktuell sind keine Erinnerungen gespeichert. Im Fahrplan
+		kannst du über das entsprechende Symbol in der ActionBar
+		für jeden Eintrag eine individuelle Erinnerung festlegen.
+	</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -64,4 +64,9 @@
 	<string name="pref_auto_download">Automatic updates</string>
 	<string name="parsing_error_generic">Unknown error while parsing schedule</string>
 	<string name="parsing_error_with_version">Parsing error for schedule version %s</string>
+	<string name="alarms_empty">
+		There are no alarms to display. Please note that you
+		can set up individual alarms for each item in the schedule.
+		Just press the alarm icon in the action bar.
+	</string>
 </resources>


### PR DESCRIPTION
Please double check if `android:orientation="vertical"` is correct for all three `alarms*.xml`. I will update this branch if any of these is incorrect.
