### PR TITLE
Let parsing fail when XML is invalid.

### DIFF
--- a/src/nerd/tuxmobil/fahrplan/congress/FahrplanParser.java
+++ b/src/nerd/tuxmobil/fahrplan/congress/FahrplanParser.java
@@ -80,11 +80,13 @@ class parser extends AsyncTask<String, Void, Boolean> {
 
 	protected Boolean doInBackground(String... args) {
 		boolean parsingSuccessful = parseFahrplan(args[0], args[1]);
-		DateFieldValidation dateFieldValidation = new DateFieldValidation(context);
-		boolean dateFieldValidationSuccessful = dateFieldValidation.validate();
-		dateFieldValidation.printValidationErrors();
-		// TODO Clear database on validation failure.
-		return parsingSuccessful; //&& dateFieldValidationSuccessful;
+		if (parsingSuccessful) {
+			DateFieldValidation dateFieldValidation = new DateFieldValidation(context);
+			dateFieldValidation.validate();
+			dateFieldValidation.printValidationErrors();
+			// TODO Clear database on validation failure.
+		}
+		return parsingSuccessful;
 	}
 
 	protected void onCancelled() {
@@ -206,6 +208,10 @@ class parser extends AsyncTask<String, Void, Boolean> {
 						day = Integer.parseInt(index);
 						date = parser.getAttributeValue(null, "date");
 						String end = parser.getAttributeValue(null, "end");
+						if (end == null) {
+							MyApp.LogDebug(LOG_TAG, "Current day: date = " + date + ", index = " + day);
+							throw new MissingXmlAttributeException("day", "end");
+						}
 						dayChangeTime = DateHelper.getDayChange(end);
 						if (day > numdays) { numdays = day; }
 					}

--- a/src/nerd/tuxmobil/fahrplan/congress/MissingXmlAttributeException.java
+++ b/src/nerd/tuxmobil/fahrplan/congress/MissingXmlAttributeException.java
@@ -1,0 +1,16 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+public class MissingXmlAttributeException extends IllegalStateException {
+
+    /**
+     * Default constructor
+     * @param elementName The name of the containing XML element
+     * @param missingAttributeName The name of the XML attribute which cannot be found
+     */
+    public MissingXmlAttributeException(final String elementName,
+                                        final String missingAttributeName) {
+        super("The <" + elementName + "> element does not contain " +
+                "the mandatory '" + missingAttributeName + "' attribute.");
+    }
+
+}


### PR DESCRIPTION
- Check for missing 'end' attribute in 'day' element.
- Avoid running DateFieldValidation when parsing already failed since
  an exception thrown by this class causes an application crash.
  Instead show a meaningful Toast message.
