### PR TITLE
Hide "schedule" text if version is not present.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AboutDialog.java
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.text.Html;
+import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,7 +28,12 @@ public class AboutDialog extends DialogFragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         TextView text = (TextView) view.findViewById(R.id.eventVersion);
-        text.setText(getString(R.string.fahrplan) + " " + MyApp.version);
+        if (MyApp.version == null || TextUtils.isEmpty(MyApp.version)) {
+            text.setVisibility(View.GONE);
+        }
+        else {
+            text.setText(getString(R.string.fahrplan) + " " + MyApp.version);
+        }
         text = (TextView) view.findViewById(R.id.eventTitle);
         text.setText(MyApp.title);
         text = (TextView) view.findViewById(R.id.eventSubtitle);


### PR DESCRIPTION
Sometimes the conference content team does not fill out the schedule version field. As far as I could see it is not used for updating the schedule on the client side. The client behavior relies on an HTTP status `HTTP_NOT_MODIFIED` aka. `304` response sent out by the server.
- [HTTP response processing](https://github.com/tuxmobil/CampFahrplan/blob/22234364b3af61debb8253ea0f1f237cf7c6d66f/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FetchFahrplan.java#L175)
- [Up-to-date message](https://github.com/tuxmobil/CampFahrplan/blob/22234364b3af61debb8253ea0f1f237cf7c6d66f/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CustomHttpClient.java#L192)

In questions is what triggers this HTTP response in [Frab](https://github.com/manno/frab)? Maybe, @manno can answer this question? Should this field be an mandatory field?
