### PR TITLE
Bugfix: Force redrawing of the time column.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
@@ -1147,8 +1147,10 @@ public class FahrplanFragment extends SherlockFragment implements
     public boolean onNavigationItemSelected(int itemPosition, long itemId) {
         if (itemPosition < MyApp.numdays) {
             chooseDay(itemPosition);
+            fillTimes();
             return true;
         }
+        fillTimes();
         return false;
     }
 


### PR DESCRIPTION
I noticed a rendering problem regarding the time column of the schedule. As can be seen in the screenshots the event starts at `14:30` but the time column starts at `09:45`.

![Event](https://cloud.githubusercontent.com/assets/144518/5057730/c9fcb500-6cd1-11e4-9e89-cc32f5dcb6da.png) ![Schedule](https://cloud.githubusercontent.com/assets/144518/5057729/c9f98592-6cd1-11e4-976e-45ad54054c18.png) 

This can be reproduced when you build the _fiffkon14_ flavor at commit [3729a](https://github.com/johnjohndoe/CampFahrplan/commit/3729adfa4f71fed76006bea9f718a913ee952166). In order to see the bug just switch between day 1 and 2.

I recorded the behavior here:

![Screen capture](https://cloud.githubusercontent.com/assets/144518/5158635/829ec30a-7344-11e4-911b-5cf771fdf478.gif)

---

I decided to **force redrawing** the time column whenever the day is switched. We should however discuss if a smarter solution can be found before this is merged into upstream.
