### PR TITLE
Use https for all links to events.ccc.de.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-[ccc-events]: http://events.ccc.de
+[ccc-events]: https://events.ccc.de
 [playstore]: https://play.google.com/store/apps/details?id=nerd.tuxmobil.fahrplan.congress
 [pentabarf]: https://github.com/nevs/pentabarf
 [frab]: https://github.com/frab/frab

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ android {
             applicationId "nerd.tuxmobil.fahrplan.congress"
             signingConfig signingConfigs.ccc30c3
             buildConfigField "String", "SCHEDULE_DOMAIN", '"events.ccc.de"'
-            buildConfigField "String", "SCHEDULE_DOMAIN_PART", '"http://events.ccc.de"'
+            buildConfigField "String", "SCHEDULE_DOMAIN_PART", '"https://events.ccc.de"'
             buildConfigField "String", "SCHEDULE_EVENT_PART", '"/events/%1$s.html"'
             buildConfigField "String", "SCHEDULE_PART", '"/congress/2013/Fahrplan"'
             buildConfigField "String", "SCHEDULE_PATH", '"/congress/2013/Fahrplan/schedule.xml"'
@@ -84,7 +84,7 @@ android {
             applicationId "nerd.tuxmobil.fahrplan.congress"
             signingConfig signingConfigs.ccc31c3
             buildConfigField "String", "SCHEDULE_DOMAIN", '"events.ccc.de"'
-            buildConfigField "String", "SCHEDULE_DOMAIN_PART", '"http://events.ccc.de"'
+            buildConfigField "String", "SCHEDULE_DOMAIN_PART", '"https://events.ccc.de"'
             buildConfigField "String", "SCHEDULE_EVENT_PART", '"/events/%1$s.html"'
             buildConfigField "String", "SCHEDULE_PART", '"/congress/2014/Fahrplan"'
             buildConfigField "String", "SCHEDULE_PATH", '"/congress/2014/Fahrplan/schedule.xml"'

--- a/app/src/ccc30c3/res/values-de/strings.xml
+++ b/app/src/ccc30c3/res/values-de/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">30C3 Fahrplan</string>
     <string name="conference_url">
-		<![CDATA[<a href="http://events.ccc.de/congress/2013/">http://events.ccc.de/congress/2013/</a>]]>
+		<![CDATA[<a href="https://events.ccc.de/congress/2013/">https://events.ccc.de/congress/2013/</a>]]>
     </string>
     <string name="source_code">
 		<![CDATA[<a href="http://github.com/tuxmobil/CampFahrplan">Quellcode</a>]]>

--- a/app/src/ccc30c3/res/values/strings.xml
+++ b/app/src/ccc30c3/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">30C3 Schedule</string>
     <string name="conference_url">
-		<![CDATA[<a href="http://events.ccc.de/congress/2013/">http://events.ccc.de/congress/2013/</a>]]>
+		<![CDATA[<a href="https://events.ccc.de/congress/2013/">https://events.ccc.de/congress/2013/</a>]]>
     </string>
     <string name="source_code">
 		<![CDATA[<a href="http://github.com/tuxmobil/CampFahrplan">Source code</a>]]>

--- a/app/src/ccc31c3/res/values-de/strings.xml
+++ b/app/src/ccc31c3/res/values-de/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">31C3 Fahrplan</string>
     <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/congress/2014/">http://events.ccc.de/congress/2014/</a>]]>
+        <![CDATA[<a href="https://events.ccc.de/congress/2014/">https://events.ccc.de/congress/2014/</a>]]>
     </string>
     <string name="source_code">
         <![CDATA[<a href="http://github.com/tuxmobil/CampFahrplan">Quellcode</a>]]>

--- a/app/src/ccc31c3/res/values/strings.xml
+++ b/app/src/ccc31c3/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">31C3 Schedule</string>
     <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/congress/2014/">http://events.ccc.de/congress/2014/</a>]]>
+        <![CDATA[<a href="https://events.ccc.de/congress/2014/">https://events.ccc.de/congress/2014/</a>]]>
     </string>
     <string name="source_code">
         <![CDATA[<a href="http://github.com/tuxmobil/CampFahrplan">Source code</a>]]>


### PR DESCRIPTION
This should rewrite the URLs when sharing links and on the bottom of the descriptions to use https.

Untested due to lack of Android SDK, sorry.