### PR TITLE
Bugfix: Avoid crash when tapping on header in favorite list.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StarredListFragment.java
@@ -101,7 +101,7 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
             mListView = (ListView) view.findViewById(android.R.id.list);
             header = localInflater.inflate(R.layout.header_empty, null, false);
         }
-        mListView.addHeaderView(header);
+        mListView.addHeaderView(header, null, false);
         mListView.setHeaderDividersEnabled(false);
 
         // Set the adapter


### PR DESCRIPTION
+ Selecting the header causes an `ArrayIndexOutOfBoundsException`
  in `onListItemClick()` since the position of the item is `0`
  which is then decremented ...