### PR TITLE
Update alert dialogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,9 +103,4 @@ android {
 
 dependencies {
     compile "com.android.support:appcompat-v7:22.2.1"
-    compile 'com.afollestad:material-dialogs:0.4.6'
-}
-
-repositories {
-    maven { url 'http://clinker.47deg.com/nexus/content/groups/public' }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlarmTimePickerFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlarmTimePickerFragment.java
@@ -1,0 +1,77 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+
+public class AlarmTimePickerFragment extends DialogFragment {
+
+    public static final String FRAGMENT_TAG =
+            BuildConfig.APPLICATION_ID + ".ALERT_TIME_PICKER_FRAGMENT_TAG";
+
+    public static final String ALARM_PICKED_INTENT_KEY =
+            BuildConfig.APPLICATION_ID + ".ALERT_TIME_PICKER_INTENT_KEY";
+
+    public static final int ALERT_TIME_PICKED_RESULT_CODE = 120166;
+
+    protected Spinner spinner;
+
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Context activity = getActivity();
+        LayoutInflater inflater = (LayoutInflater) activity
+                .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        @SuppressLint("InflateParams")
+        View layout = inflater.inflate(R.layout.reminder_dialog, null, false);
+        // https://possiblemobile.com/2013/05/layout-inflation-as-intended/
+        initializeSpinner(layout);
+
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(activity);
+        dialogBuilder
+                .setView(layout)
+                .setTitle(R.string.choose_alarm_time)
+                .setPositiveButton(android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                passBackAlarmTimesIndex();
+                            }
+                        })
+                .setNegativeButton(android.R.string.cancel, null);
+        return dialogBuilder.create();
+    }
+
+    private void initializeSpinner(@NonNull View rootView) {
+        spinner = (Spinner) rootView.findViewById(R.id.spinner);
+        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
+                getActivity(),
+                R.array.alarm_array,
+                android.R.layout.simple_spinner_item);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinner.setAdapter(adapter);
+    }
+
+    private void passBackAlarmTimesIndex() {
+        int alarmTimesIndex = spinner.getSelectedItemPosition();
+        Intent intent = new Intent();
+        intent.putExtra(ALARM_PICKED_INTENT_KEY, alarmTimesIndex);
+        Fragment fragment = getTargetFragment();
+        if (fragment == null) {
+            throw new NullPointerException("Target fragment is null.");
+        }
+        fragment.onActivityResult(getTargetRequestCode(), ALERT_TIME_PICKED_RESULT_CODE, intent);
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlertDialogHelper.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlertDialogHelper.java
@@ -1,0 +1,23 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.v7.app.AlertDialog;
+
+public abstract class AlertDialogHelper {
+
+    public static void showErrorDialog(
+            @NonNull final Context context,
+            @StringRes final int title,
+            @StringRes final int message,
+            @Nullable final Object... messageArguments) {
+        new AlertDialog.Builder(context)
+                .setTitle(title)
+                .setMessage(context.getString(message, messageArguments))
+                .setPositiveButton(R.string.OK, null)
+                .show();
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -1,16 +1,14 @@
 package nerd.tuxmobil.fahrplan.congress;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Dialog;
+import android.support.v7.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
-
-import com.afollestad.materialdialogs.MaterialDialogCompat;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -37,7 +35,7 @@ public class CertificateDialogFragment extends DialogFragment {
 
     private static void showErrorDialog(final int msgResId, final Activity ctx,
             final Object... args) {
-        new MaterialDialogCompat.Builder(ctx).setTitle(
+        new AlertDialog.Builder(ctx).setTitle(
                 ctx.getString(R.string.dlg_invalid_certificate_could_not_apply))
                 .setMessage(ctx.getString(msgResId, args))
                 .setPositiveButton(ctx.getString(R.string.OK),
@@ -111,7 +109,7 @@ public class CertificateDialogFragment extends DialogFragment {
             chainInfo.append("SHA1 Fingerprint: " + getFingerPrint(chain[i])).append("\n");
         }
 
-        MaterialDialogCompat.Builder builder = new MaterialDialogCompat.Builder(getActivity())
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setTitle(getString(R.string.dlg_invalid_certificate_title))
                 .setCancelable(true)
                 .setPositiveButton(getString(android.R.string.yes),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -2,10 +2,10 @@ package nerd.tuxmobil.fahrplan.congress;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.support.v7.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
@@ -31,19 +31,6 @@ public class CertificateDialogFragment extends DialogFragment {
     public void onAttach(Activity activity) {
         super.onAttach(activity);
         listener = (OnCertAccepted) activity;
-    }
-
-    private static void showErrorDialog(final int msgResId, final Activity ctx,
-            final Object... args) {
-        new AlertDialog.Builder(ctx).setTitle(
-                ctx.getString(R.string.dlg_invalid_certificate_could_not_apply))
-                .setMessage(ctx.getString(msgResId, args))
-                .setPositiveButton(ctx.getString(R.string.OK),
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog,
-                                    int which) {
-                            }
-                        }).show();
     }
 
     private static String getFingerPrint(X509Certificate cert) {
@@ -139,9 +126,12 @@ public class CertificateDialogFragment extends DialogFragment {
                 listener.cert_accepted();
             }
         } catch (CertificateException e) {
-            showErrorDialog(R.string.dlg_certificate_message_fmt,
+            String messageArguments = e.getMessage() == null ? "" : e.getMessage();
+            AlertDialogHelper.showErrorDialog(
                     getActivity(),
-                    e.getMessage() == null ? "" : e.getMessage());
+                    R.string.dlg_invalid_certificate_could_not_apply,
+                    R.string.dlg_certificate_message_fmt,
+                    messageArguments);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
@@ -59,6 +60,7 @@ public class CertificateDialogFragment extends DialogFragment {
         return hash.toString();
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         chain = TrustManagerFactory.getLastCertChain();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -118,13 +118,7 @@ public class CertificateDialogFragment extends DialogFragment {
                                 onConfirm();
                             }
                         })
-                .setNegativeButton(getString(android.R.string.no),
-
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog,
-                                    int which) {
-                            }
-                        });
+                .setNegativeButton(getString(android.R.string.no), null);
 
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View msgView = inflater.inflate(R.layout.cert_dialog, null);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -122,9 +122,10 @@ public class CertificateDialogFragment extends DialogFragment {
 
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View msgView = inflater.inflate(R.layout.cert_dialog, null);
-        ((TextView) msgView.findViewById(R.id.cert)).setText(
-                getString(R.string.dlg_certificate_message_fmt, exMessage) + "\n\n" + chainInfo
-                        .toString());
+        TextView messageView = (TextView) msgView.findViewById(R.id.cert);
+        String message = getString(R.string.dlg_certificate_message_fmt, exMessage);
+        message += "\n\n" + chainInfo.toString();
+        messageView.setText(message);
         builder.setView(msgView);
         return builder.create();
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -113,21 +113,9 @@ public class CertificateDialogFragment extends DialogFragment {
                 .setTitle(getString(R.string.dlg_invalid_certificate_title))
                 .setCancelable(true)
                 .setPositiveButton(getString(android.R.string.yes),
-
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
-                                try {
-                                    if (chain != null) {
-                                        TrustManagerFactory.addCertificateChain(chain);
-                                    }
-                                    if (listener != null) {
-                                        listener.cert_accepted();
-                                    }
-                                } catch (CertificateException e) {
-                                    showErrorDialog(R.string.dlg_certificate_message_fmt,
-                                            getActivity(),
-                                            e.getMessage() == null ? "" : e.getMessage());
-                                }
+                                onConfirm();
                             }
                         })
                 .setNegativeButton(getString(android.R.string.no),
@@ -145,6 +133,21 @@ public class CertificateDialogFragment extends DialogFragment {
                         .toString());
         builder.setView(msgView);
         return builder.create();
+    }
+
+    private void onConfirm() {
+        try {
+            if (chain != null) {
+                TrustManagerFactory.addCertificateChain(chain);
+            }
+            if (listener != null) {
+                listener.cert_accepted();
+            }
+        } catch (CertificateException e) {
+            showErrorDialog(R.string.dlg_certificate_message_fmt,
+                    getActivity(),
+                    e.getMessage() == null ? "" : e.getMessage());
+        }
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CertificateDialogFragment.java
@@ -24,6 +24,9 @@ interface OnCertAccepted {
 
 public class CertificateDialogFragment extends DialogFragment {
 
+    public static final String FRAGMENT_TAG =
+            BuildConfig.APPLICATION_ID + "CERTIFICATE_DIALOG_FRAGMENT_TAG";
+
     private OnCertAccepted listener;
 
     private X509Certificate[] chain;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ChangesDialog.java
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -80,12 +81,13 @@ public class ChangesDialog extends DialogFragment {
         span.append(" ");
         int spanStart = span.length();
         span.append(version);
-        span.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.colorAccent)),
+        Resources resources = getResources();
+        span.setSpan(new ForegroundColorSpan(resources.getColor(R.color.colorAccent)),
                 spanStart, span.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         span.append(getString(R.string.changes_dlg_text2, version,
-                getResources().getQuantityString(R.plurals.numberOfLectures, changed, changed),
-                getResources().getQuantityString(R.plurals.being, added, added),
-                getResources().getQuantityString(R.plurals.being, cancelled, cancelled)));
+                resources.getQuantityString(R.plurals.numberOfLectures, changed, changed),
+                resources.getQuantityString(R.plurals.being, added, added),
+                resources.getQuantityString(R.plurals.being, cancelled, cancelled)));
         changes1.setText(span);
 
         TextView changes2 = (TextView) msgView.findViewById(R.id.changes_dlg_text2);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ChangesDialog.java
@@ -59,30 +59,16 @@ public class ChangesDialog extends DialogFragment {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setTitle(getString(R.string.schedule_udpate))
                 .setPositiveButton(R.string.btn_dlg_browse,
-
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
-                                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences
-                                        (getActivity());
-                                SharedPreferences.Editor edit = prefs.edit();
-                                edit.putBoolean(BundleKeys.PREFS_CHANGES_SEEN, true);
-                                edit.commit();
-
-                                FragmentActivity activity = getActivity();
-                                if (activity instanceof MainActivity) {
-                                    ((MainActivity)activity).openLectureChanges();
-                                }
+                                onBrowse();
                             }
                         })
                 .setNegativeButton(R.string.btn_dlg_later,
                         new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences
-                                        (getActivity());
-                                SharedPreferences.Editor edit = prefs.edit();
-                                edit.putBoolean(BundleKeys.PREFS_CHANGES_SEEN, true);
-                                edit.commit();
+                                onLater();
                             }
                         });
 
@@ -107,4 +93,24 @@ public class ChangesDialog extends DialogFragment {
         builder.setView(msgView);
         return builder.create();
     }
+
+    private void onBrowse() {
+        flagChangesAsSeen();
+        FragmentActivity activity = getActivity();
+        if (activity instanceof MainActivity) {
+            ((MainActivity)activity).openLectureChanges();
+        }
+    }
+
+    private void onLater() {
+        flagChangesAsSeen();
+    }
+
+    private void flagChangesAsSeen() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences.Editor edit = prefs.edit();
+        edit.putBoolean(BundleKeys.PREFS_CHANGES_SEEN, true);
+        edit.commit();
+    }
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ChangesDialog.java
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
@@ -9,6 +8,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.AlertDialog;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.ForegroundColorSpan;
@@ -17,8 +17,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
-
-import com.afollestad.materialdialogs.MaterialDialogCompat;
 
 public class ChangesDialog extends DialogFragment {
 
@@ -58,7 +56,7 @@ public class ChangesDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialogCompat.Builder builder = new MaterialDialogCompat.Builder(getActivity())
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setTitle(getString(R.string.schedule_udpate))
                 .setPositiveButton(R.string.btn_dlg_browse,
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
@@ -11,24 +11,24 @@ import android.support.v7.app.AlertDialog;
 public class ConfirmationDialog extends DialogFragment {
 
     interface OnConfirmationDialogClicked {
-        void onAccepted(int dlgId);
+        void onAccepted(int dlgRequestCode);
 
-        void onDenied(int dlgId);
+        void onDenied(int dlgRequestCode);
     }
 
     public static final String BUNDLE_DLG_TITLE = "ConfirmationDialog.DLG_TITLE";
-    public static final String BUNDLE_DLG_ID = "ConfirmationDialog.DLG_ID";
+    public static final String BUNDLE_DLG_REQUEST_CODE = "ConfirmationDialog.DLG_REQUEST_CODE";
     public static final String TAG = "ConfirmationDialog.FRAGMENT_TAG";
     private int dlgTitle;
-    private int dlgId;
+    private int dlgRequestCode;
     private OnConfirmationDialogClicked listener;
 
-    public static ConfirmationDialog newInstance(@StringRes int dlgTitle, int dlgId) {
+    public static ConfirmationDialog newInstance(@StringRes int dlgTitle, int requestCode) {
         ConfirmationDialog dialog = new ConfirmationDialog();
         dialog.listener = null;
         Bundle args = new Bundle();
         args.putInt(BUNDLE_DLG_TITLE, dlgTitle);
-        args.putInt(BUNDLE_DLG_ID, dlgId);
+        args.putInt(BUNDLE_DLG_REQUEST_CODE, requestCode);
         dialog.setArguments(args);
         dialog.setCancelable(false);
         return dialog;
@@ -40,7 +40,7 @@ public class ConfirmationDialog extends DialogFragment {
         Bundle args = getArguments();
         if (args != null) {
             dlgTitle = args.getInt(BUNDLE_DLG_TITLE);
-            dlgId = args.getInt(BUNDLE_DLG_ID);
+            dlgRequestCode = args.getInt(BUNDLE_DLG_REQUEST_CODE);
         }
     }
 
@@ -52,7 +52,7 @@ public class ConfirmationDialog extends DialogFragment {
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
                                 if (listener != null) {
-                                    listener.onAccepted(dlgId);
+                                    listener.onAccepted(dlgRequestCode);
                                 }
                             }
                         })
@@ -61,7 +61,7 @@ public class ConfirmationDialog extends DialogFragment {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 if (listener != null) {
-                                    listener.onDenied(dlgId);
+                                    listener.onDenied(dlgRequestCode);
                                 }
                             }
                         });

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
@@ -50,7 +50,7 @@ public class ConfirmationDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setTitle(dlgTitle)
-                .setPositiveButton(android.R.string.yes,
+                .setPositiveButton(R.string.dlg_delete_all_favorites_delete_all,
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
                                 if (listener != null) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
@@ -44,6 +45,7 @@ public class ConfirmationDialog extends DialogFragment {
         }
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
@@ -5,8 +5,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
-
-import com.afollestad.materialdialogs.MaterialDialogCompat;
+import android.support.v7.app.AlertDialog;
 
 public class ConfirmationDialog extends DialogFragment {
 
@@ -50,7 +49,7 @@ public class ConfirmationDialog extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialogCompat.Builder builder = new MaterialDialogCompat.Builder(getActivity())
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setMessage(dlgText)
                 .setPositiveButton(android.R.string.yes,
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConfirmationDialog.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 
@@ -15,20 +16,17 @@ public class ConfirmationDialog extends DialogFragment {
         void onDenied(int dlgId);
     }
 
-    public static final String BUNDLE_DLG_TEXT = "ConfirmationDialog.DLG_TEXT";
     public static final String BUNDLE_DLG_TITLE = "ConfirmationDialog.DLG_TITLE";
     public static final String BUNDLE_DLG_ID = "ConfirmationDialog.DLG_ID";
     public static final String TAG = "ConfirmationDialog.FRAGMENT_TAG";
-    private int dlgText;
     private int dlgTitle;
     private int dlgId;
     private OnConfirmationDialogClicked listener;
 
-    public static ConfirmationDialog newInstance(int dlgTitle, int dlgText, int dlgId) {
+    public static ConfirmationDialog newInstance(@StringRes int dlgTitle, int dlgId) {
         ConfirmationDialog dialog = new ConfirmationDialog();
         dialog.listener = null;
         Bundle args = new Bundle();
-        args.putInt(BUNDLE_DLG_TEXT, dlgText);
         args.putInt(BUNDLE_DLG_TITLE, dlgTitle);
         args.putInt(BUNDLE_DLG_ID, dlgId);
         dialog.setArguments(args);
@@ -41,7 +39,6 @@ public class ConfirmationDialog extends DialogFragment {
         super.onCreate(savedInstanceState);
         Bundle args = getArguments();
         if (args != null) {
-            dlgText = args.getInt(BUNDLE_DLG_TEXT);
             dlgTitle = args.getInt(BUNDLE_DLG_TITLE);
             dlgId = args.getInt(BUNDLE_DLG_ID);
         }
@@ -50,9 +47,8 @@ public class ConfirmationDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
-                .setMessage(dlgText)
+                .setTitle(dlgTitle)
                 .setPositiveButton(android.R.string.yes,
-
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
                                 if (listener != null) {
@@ -69,8 +65,6 @@ public class ConfirmationDialog extends DialogFragment {
                                 }
                             }
                         });
-
-        if (dlgTitle != 0) builder.setTitle(dlgTitle);
         return builder.create();
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CustomHttpClient.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CustomHttpClient.java
@@ -12,15 +12,13 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.net.http.AndroidHttpClient;
 import android.os.Build;
+import android.support.v7.app.AlertDialog;
 import android.util.Base64;
 import android.widget.Toast;
-
-import com.afollestad.materialdialogs.MaterialDialogCompat;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -110,7 +108,7 @@ public class CustomHttpClient {
 
     public static void showErrorDialog(final Activity ctx, final int msgTitle, final int msgText,
             final Object... args) {
-        new MaterialDialogCompat.Builder(ctx).setTitle(
+        new AlertDialog.Builder(ctx).setTitle(
                 ctx.getString(msgTitle))
                 .setMessage(ctx.getString(msgText, args))
                 .setPositiveButton(ctx.getString(R.string.OK),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CustomHttpClient.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/CustomHttpClient.java
@@ -13,10 +13,8 @@ import org.apache.http.params.HttpProtocolParams;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.net.http.AndroidHttpClient;
 import android.os.Build;
-import android.support.v7.app.AlertDialog;
 import android.util.Base64;
 import android.widget.Toast;
 
@@ -106,20 +104,6 @@ public class CustomHttpClient {
         return lastSSLException;
     }
 
-    public static void showErrorDialog(final Activity ctx, final int msgTitle, final int msgText,
-            final Object... args) {
-        new AlertDialog.Builder(ctx).setTitle(
-                ctx.getString(msgTitle))
-                .setMessage(ctx.getString(msgText, args))
-                .setPositiveButton(ctx.getString(R.string.OK),
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog,
-                                    int which) {
-                                //ctx.finish();
-                            }
-                        }).show();
-    }
-
     public static String getAddr() {
         return "events.ccc.de";
     }
@@ -149,43 +133,43 @@ public class CustomHttpClient {
     public static void showHttpError(final Activity ctx, MyApp global, HTTP_STATUS status, String host) {
         switch (status) {
             case HTTP_LOGIN_FAIL_WRONG_PASSWORD:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_wrong_password, (Object) null);
                 break;
             case HTTP_DNS_FAILURE:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_unknown_host,
                         host);
                 break;
             case HTTP_WRONG_HTTP_CREDENTIALS:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_wrong_http_credentials, (Object) null);
                 break;
             case HTTP_CONNECT_TIMEOUT:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_timeout, (Object) null);
                 break;
             case HTTP_COULD_NOT_CONNECT:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_connect_failure, (Object) null);
                 break;
             case HTTP_ENTITY_ENCODING_FAILURE:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_encoding_failure, (Object) null);
                 break;
             case HTTP_CANNOT_PARSE_CONTENT:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_parse_failure, (Object) null);
                 break;
             case HTTP_SSL_SETUP_FAILURE:
-                CustomHttpClient.showErrorDialog(ctx,
+                AlertDialogHelper.showErrorDialog(ctx,
                         R.string.dlg_err_connection_failed,
                         R.string.dlg_err_failed_ssl_failure, (Object) null);
                 break;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -10,6 +9,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.AlertDialog;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
@@ -21,8 +21,6 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
-
-import com.afollestad.materialdialogs.MaterialDialogCompat;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -277,7 +275,7 @@ public class EventDetailFragment extends Fragment {
         TextView msg = (TextView) layout.findViewById(R.id.message);
         msg.setText(R.string.choose_alarm_time);
 
-        new MaterialDialogCompat.Builder(getActivity()).setTitle(R.string.setup_alarm)
+        new AlertDialog.Builder(getActivity()).setTitle(R.string.setup_alarm)
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok,
                         new DialogInterface.OnClickListener() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
@@ -272,10 +272,7 @@ public class EventDetailFragment extends Fragment {
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinner.setAdapter(adapter);
 
-        TextView msg = (TextView) layout.findViewById(R.id.message);
-        msg.setText(R.string.choose_alarm_time);
-
-        new AlertDialog.Builder(getActivity()).setTitle(R.string.setup_alarm)
+        new AlertDialog.Builder(getActivity()).setTitle(R.string.choose_alarm_time)
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok,
                         new DialogInterface.OnClickListener() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress;
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -12,10 +11,10 @@ import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
-import android.support.v7.app.AlertDialog;
 import android.text.format.Time;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -33,7 +32,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.ScrollView;
-import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -60,6 +58,8 @@ public class FahrplanFragment extends Fragment implements
     private MyApp global;
 
     private static String LOG_TAG = "Fahrplan";
+
+    public static final int FAHRPLAN_FRAGMENT_REQUEST_CODE = 6166;
 
     private float scale;
 
@@ -103,6 +103,8 @@ public class FahrplanFragment extends Fragment implements
     private String lecture_id;        // started with lecture_id
     private HashMap<String, Integer> trackAccentColors;
     private HashMap<String, Integer> trackAccentColorsHighlight;
+
+    private Lecture lastSelectedLecture;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -917,40 +919,37 @@ public class FahrplanFragment extends Fragment implements
         }
     }
 
-    void getAlarmTimeDialog(final Lecture lecture) {
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == FAHRPLAN_FRAGMENT_REQUEST_CODE &&
+                resultCode == AlarmTimePickerFragment.ALERT_TIME_PICKED_RESULT_CODE) {
+            int alarmTimesIndex = data.getIntExtra(
+                    AlarmTimePickerFragment.ALARM_PICKED_INTENT_KEY, 0);
+            onAlarmTimesIndexPicked(alarmTimesIndex);
+        }
+        super.onActivityResult(requestCode, resultCode, data);
+    }
 
-        LayoutInflater inflater = (LayoutInflater) getActivity()
-                .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        View layout = inflater.inflate(R.layout.reminder_dialog,
-                (ViewGroup) getView().findViewById(R.id.layout_root));
+    private void showAlarmTimePicker() {
+        DialogFragment dialogFragment = new AlarmTimePickerFragment();
+        dialogFragment.setTargetFragment(this, FAHRPLAN_FRAGMENT_REQUEST_CODE);
+        dialogFragment.show(getActivity().getSupportFragmentManager(),
+                AlarmTimePickerFragment.FRAGMENT_TAG);
+    }
 
-        final Spinner spinner = (Spinner) layout.findViewById(R.id.spinner);
-        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
-                getActivity(),
-                R.array.alarm_array,
-                android.R.layout.simple_spinner_item);
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spinner.setAdapter(adapter);
-
-        new AlertDialog.Builder(getActivity()).setTitle(R.string.choose_alarm_time)
-                .setView(layout)
-                .setPositiveButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog,
-                                    int which) {
-                                int alarm = spinner.getSelectedItemPosition();
-                                MyApp.LogDebug(LOG_TAG, "alarm chosen: " + alarm);
-                                FahrplanMisc.addAlarm(getActivity(), lecture, alarm);
-                                setBell(lecture);
-                            }
-                        }).setNegativeButton(android.R.string.cancel, null)
-                .create().show();
+    private void onAlarmTimesIndexPicked(int alarmTimesIndex) {
+        if (lastSelectedLecture == null) {
+            throw new NullPointerException("Lecture is null.");
+        }
+        FahrplanMisc.addAlarm(getActivity(), lastSelectedLecture, alarmTimesIndex);
+        setBell(lastSelectedLecture);
     }
 
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         int menuItemIndex = item.getItemId();
         Lecture lecture = (Lecture) contextMenuView.getTag();
+        lastSelectedLecture = lecture;
 
         MyApp.LogDebug(LOG_TAG, "clicked on " + ((Lecture) contextMenuView.getTag()).lecture_id);
 
@@ -971,7 +970,7 @@ public class FahrplanFragment extends Fragment implements
                 }
                 break;
             case 1:
-                getAlarmTimeDialog(lecture);
+                showAlarmTimePicker();
                 break;
             case 2:
                 FahrplanMisc.deleteAlarm(getActivity(), lecture);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
@@ -932,10 +932,7 @@ public class FahrplanFragment extends Fragment implements
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinner.setAdapter(adapter);
 
-        TextView msg = (TextView) layout.findViewById(R.id.message);
-        msg.setText(R.string.choose_alarm_time);
-
-        new AlertDialog.Builder(getActivity()).setTitle(R.string.setup_alarm)
+        new AlertDialog.Builder(getActivity()).setTitle(R.string.choose_alarm_time)
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok,
                         new DialogInterface.OnClickListener() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanFragment.java
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -16,6 +15,7 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AlertDialog;
 import android.text.format.Time;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -36,8 +36,6 @@ import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import com.afollestad.materialdialogs.MaterialDialogCompat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -937,7 +935,7 @@ public class FahrplanFragment extends Fragment implements
         TextView msg = (TextView) layout.findViewById(R.id.message);
         msg.setText(R.string.choose_alarm_time);
 
-        new MaterialDialogCompat.Builder(getActivity()).setTitle(R.string.setup_alarm)
+        new AlertDialog.Builder(getActivity()).setTitle(R.string.setup_alarm)
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok,
                         new DialogInterface.OnClickListener() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MainActivity.java
@@ -147,9 +147,7 @@ public class MainActivity extends ActionBarActivity
                     break;
                 case HTTP_LOGIN_FAIL_UNTRUSTED_CERTIFICATE:
                     CertificateDialogFragment dlg = new CertificateDialogFragment();
-                    Bundle args = new Bundle();
-                    args.putInt("msgResId", R.string.dlg_certificate_message_fmt);
-                    dlg.show(getSupportFragmentManager(), "cert_dlg");
+                    dlg.show(getSupportFragmentManager(), CertificateDialogFragment.FRAGMENT_TAG);
                     break;
             }
             CustomHttpClient.showHttpError(this, global, status, host);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MainActivity.java
@@ -515,12 +515,12 @@ public class MainActivity extends ActionBarActivity
     }
 
     @Override
-    public void onAccepted(int dlgId) {
-        switch (dlgId) {
-            case 0:
+    public void onAccepted(int dlgRequestCode) {
+        switch (dlgRequestCode) {
+            case StarredListFragment.DELETE_ALL_FAVORITES_REQUEST_CODE:
                 FragmentManager fm = getSupportFragmentManager();
-                StarredListFragment fragment = (StarredListFragment)fm.findFragmentByTag(FahrplanContract
-                        .FragmentTags.STARRED);
+                StarredListFragment fragment = (StarredListFragment)fm.findFragmentByTag(
+                        FahrplanContract.FragmentTags.STARRED);
                 if (fragment != null) {
                     fragment.deleteAllFavorites();
                 }
@@ -529,7 +529,7 @@ public class MainActivity extends ActionBarActivity
     }
 
     @Override
-    public void onDenied(int dlgId) {
+    public void onDenied(int dlgRequestCode) {
     }
 
     public static MainActivity getInstance() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StarredListFragment.java
@@ -40,6 +40,8 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
     private LectureList starredList;
     private boolean sidePane = false;
 
+    public static final int DELETE_ALL_FAVORITES_REQUEST_CODE = 19126;
+
     /**
      * The fragment's ListView/GridView.
      */
@@ -274,7 +276,7 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
         if (fragment == null) {
             ConfirmationDialog confirm = ConfirmationDialog.newInstance(
                     R.string.dlg_delete_all_favorites,
-                    0);
+                    DELETE_ALL_FAVORITES_REQUEST_CODE);
             confirm.show(fm, ConfirmationDialog.TAG);
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StarredListFragment.java
@@ -268,13 +268,13 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
         jumpOverPastLectures();
     }
 
-    private void askToDeleteAllFavorites()
-    {
+    private void askToDeleteAllFavorites() {
         FragmentManager fm = getActivity().getSupportFragmentManager();
         Fragment fragment = fm.findFragmentByTag(ConfirmationDialog.TAG);
-
         if (fragment == null) {
-            ConfirmationDialog confirm = ConfirmationDialog.newInstance(0, R.string.dlg_delete_all_favorites, 0);
+            ConfirmationDialog confirm = ConfirmationDialog.newInstance(
+                    R.string.dlg_delete_all_favorites,
+                    0);
             confirm.show(fm, ConfirmationDialog.TAG);
         }
     }

--- a/app/src/main/res/layout/cert_dialog.xml
+++ b/app/src/main/res/layout/cert_dialog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -13,6 +14,7 @@
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:textSize="12sp"
+                tools:text="@string/dlg_certificate_message_fmt"
                 />
 
     </LinearLayout>

--- a/app/src/main/res/layout/cert_dialog.xml
+++ b/app/src/main/res/layout/cert_dialog.xml
@@ -13,6 +13,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
+                android:layout_margin="@dimen/alert_dialog_content_margin"
                 android:textSize="12sp"
                 tools:text="@string/dlg_certificate_message_fmt"
                 />

--- a/app/src/main/res/layout/cert_dialog.xml
+++ b/app/src/main/res/layout/cert_dialog.xml
@@ -14,7 +14,7 @@
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:layout_margin="@dimen/alert_dialog_content_margin"
-                android:textSize="12sp"
+                android:textSize="@dimen/certificate_dialog_text"
                 tools:text="@string/dlg_certificate_message_fmt"
                 />
 

--- a/app/src/main/res/layout/changes_dialog.xml
+++ b/app/src/main/res/layout/changes_dialog.xml
@@ -3,6 +3,7 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
+              android:padding="@dimen/alert_dialog_content_margin"
               >
 
     <TextView

--- a/app/src/main/res/layout/reminder_dialog.xml
+++ b/app/src/main/res/layout/reminder_dialog.xml
@@ -6,16 +6,9 @@
         android:orientation="vertical"
         android:id="@+id/layout_root">
 
-    <TextView
-            android:text="TextView"
-            android:textAppearance="@android:style/TextAppearance.Medium"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/message"
-            android:paddingBottom="8dp"></TextView>
-
     <Spinner
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_margin="@dimen/alert_dialog_content_margin"
             android:id="@+id/spinner"></Spinner>
 </LinearLayout>

--- a/app/src/main/res/layout/reminder_dialog.xml
+++ b/app/src/main/res/layout/reminder_dialog.xml
@@ -7,7 +7,7 @@
         android:id="@+id/layout_root">
 
     <Spinner
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/alert_dialog_content_margin"
             android:id="@+id/spinner"></Spinner>

--- a/app/src/main/res/layout/reminder_dialog.xml
+++ b/app/src/main/res/layout/reminder_dialog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
@@ -10,5 +10,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/alert_dialog_content_margin"
-            android:id="@+id/spinner"></Spinner>
+            android:id="@+id/spinner"
+            tools:listitem="@android:layout/simple_spinner_dropdown_item"/>
+
 </LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="OK">OK</string>
-	<string name="dlg_certificate_message_fmt">Aufbau einer gesicherten Verbindung nicht
-		möglich.\n(%s)</string>
+	<string name="dlg_certificate_message_fmt">
+        Aufbau einer gesicherten Verbindung nicht möglich.\n
+        (<xliff:g id="error" example="Unbekannter Fehler">%s</xliff:g>)
+    </string>
     <string name="dlg_invalid_certificate_title">Unbekanntem Zertifikat vertrauen?</string>
     <string name="dlg_invalid_certificate_accept">Akzeptieren</string>
     <string name="dlg_invalid_certificate_reject">Ablehnen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -41,8 +41,7 @@
         <item>45 Minuten</item>
         <item>60 Minuten</item>
     </string-array>
-    <string name="choose_alarm_time">Wähle die Alarmzeit:</string>
-    <string name="setup_alarm">Alarm einstellen</string>
+    <string name="choose_alarm_time">Wähle die Alarmzeit</string>
     <string name="reminders">Erinnerungen</string>
     <string name="reminder">Erinnerung</string>
     <string name="feedback">Feedback</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -52,7 +52,8 @@
     <string name="usage">Hinweis:\n\nLange auf Vortrag tippen, um Erinnerung einzustellen.</string>
     <string name="set_alarm">Alarm setzen</string>
 	<string name="libraries">
-		Die Anwendung nutzt folgende Bibliotheken: Google Support Library v4, Google AppCompat Library v7, material-dialogs by afollestad
+		Die Anwendung nutzt folgende Bibliotheken:
+		Google Support Library v4, Google AppCompat Library v7
 	</string>
     <string name="copyright_notes">Copyright 2015 Daniel Dorau.\nCopyright 2015 SubOptimal, entropynil, johnjohndoe.\nPortions Copyright 2008-2011 The K-9 Dog Walkers and 2006-2013 the Android Open Source Project.</string>
     <string name="copyright_logo">30C3-Artwork von <![CDATA[<a href="http://evelynschubert.com/">Evelyn Schubert</a>]]>, unter <![CDATA[<a href="http://creativecommons.org/licenses/by-sa/3.0/deed.en_US">CC BY-SA 3.0</a>]]> lizenziert</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -109,4 +109,5 @@
     <string name="btn_dlg_later">Später</string>
     <string name="alternative_highlight">Alternative Hervorhebung</string>
     <string name="dlg_delete_all_favorites">Alle Favoriten löschen?</string>
+    <string name="dlg_delete_all_favorites_delete_all">Alle löschen</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,11 @@
     <color name="lecture_detailbar_background">#eee</color>
     <color name="lecture_detailbar_text">#999</color>
 
+    <!-- Alarm dialogs -->
+    <color name="alert_dialog_title">@color/colorAccent</color>
+    <color name="alert_dialog_button_text">@color/colorPrimary</color>
+
+    <!-- Schedule changes -->
     <color name="schedule_change">#ff0000</color>
     <color name="schedule_change_new">#00ff00</color>
     <color name="schedule_change_canceled">#808080</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -33,4 +33,8 @@
     <dimen name="event_item_right_offset">1dp</dimen>
     <dimen name="event_item_selection_stroke_width">2dp</dimen>
 
+    <!-- Alert dialogs -->
+    <!-- See: https://www.google.de/design/spec/components/dialogs.html#dialogs-specs -->
+    <dimen name="alert_dialog_content_margin">24dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -36,5 +36,6 @@
     <!-- Alert dialogs -->
     <!-- See: https://www.google.de/design/spec/components/dialogs.html#dialogs-specs -->
     <dimen name="alert_dialog_content_margin">24dp</dimen>
+    <dimen name="certificate_dialog_text">12sp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,8 +40,7 @@
         <item>45 Minutes</item>
         <item>60 Minutes</item>
     </string-array>
-    <string name="choose_alarm_time">Choose alarm time:</string>
-    <string name="setup_alarm">Set alarm</string>
+    <string name="choose_alarm_time">Choose alarm time</string>
     <string name="reminders">Reminders</string>
     <string name="reminder">Reminder</string>
     <string name="feedback">Feedback</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="OK">OK</string>
-    <string name="dlg_certificate_message_fmt">Failed to establish secure connection.\n(%s)</string>
+    <string name="dlg_certificate_message_fmt">
+        Failed to establish secure connection.\n
+        (<xliff:g id="error" example="Unknown Error">%s</xliff:g>)
+    </string>
     <string name="dlg_invalid_certificate_title">Trust unknown certificate?</string>
     <string name="dlg_invalid_certificate_accept">Accept </string>
     <string name="dlg_invalid_certificate_reject">Deny </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,5 @@
     <string name="btn_dlg_later">Later</string>
     <string name="alternative_highlight">Alternative highlighting</string>
     <string name="dlg_delete_all_favorites">Delete all favorites?</string>
+    <string name="dlg_delete_all_favorites_delete_all">Delete all</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,8 @@
     <string name="usage">Note:\n\nLong-press on a lecture to set an alarm.</string>
     <string name="set_alarm">Set alarm</string>
 	<string name="libraries">
-		This application uses the following libraries: Google Support Library v4, Google AppCompat Library v7, material-dialogs by afollestad
+		This application uses the following libraries:
+		Google Support Library v4, Google AppCompat Library v7
 	</string>
     <string name="copyright_notes">Copyright 2015 Daniel Dorau.\nCopyright 2015 SubOptimal, entropynil, johnjohndoe.\nPortions Copyright 2008-2011 The K-9 Dog Walkers and 2006-2013 the Android Open Source Project.</string>
     <string name="copyright_logo">30C3 artwork by <![CDATA[<a href="http://evelynschubert.com/">Evelyn Schubert</a>]]> licensed under <![CDATA[<a href="http://creativecommons.org/licenses/by-sa/3.0/deed.en_US">CC BY-SA 3.0</a>]]></string>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -34,6 +34,7 @@
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="android:actionModeBackground">@color/colorPrimary</item>
+        <item name="alertDialogTheme">@style/AlertDialog</item>
     </style>
 
     <style name="Theme.Congress.NoActionBar" parent="Theme.AppCompat.NoActionBar">
@@ -51,6 +52,13 @@
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="android:actionModeBackground">@color/colorPrimary</item>
+        <item name="alertDialogTheme">@style/AlertDialog</item>
+    </style>
+
+    <style name="AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="colorAccent">@color/alert_dialog_button_text</item>
+        <item name="android:textColor">@color/alert_dialog_title</item>
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
     </style>
 
     <style name="MyActionDropDownStyle" parent="Widget.AppCompat.Spinner.DropDown.ActionBar">

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -34,7 +34,6 @@
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="android:actionModeBackground">@color/colorPrimary</item>
-        <item name="md_dark_theme">true</item>
     </style>
 
     <style name="Theme.Congress.NoActionBar" parent="Theme.AppCompat.NoActionBar">
@@ -52,7 +51,6 @@
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="android:actionModeBackground">@color/colorPrimary</item>
-        <item name="md_dark_theme">true</item>
     </style>
 
     <style name="MyActionDropDownStyle" parent="Widget.AppCompat.Spinner.DropDown.ActionBar">


### PR DESCRIPTION
In this branch I refactored alert dialogs. The major change is the usage of *appcompat-v7* in favor *material-dialogs* since Google meanwhile updated their implementation to allow customization following the Material guidelines. Further, I remove duplicate code here and there and cleaned up a bit (more on that at the commit messages).

### Alert dialogs after changes of this branch are applied

![Choose alarm time](https://cloud.githubusercontent.com/assets/144518/10450805/e6bc76be-719c-11e5-8202-538548294a82.png) ![Trust unknown certificate?](https://cloud.githubusercontent.com/assets/144518/10450806/e6bf6928-719c-11e5-9bd0-c5320b65e949.png) ![Schedule updates](https://cloud.githubusercontent.com/assets/144518/10450807/e6c04870-719c-11e5-9814-efb43c216139.png) ![Delete all favorites?](https://cloud.githubusercontent.com/assets/144518/10450808/e6c3f89e-719c-11e5-8457-ed4067c20018.png) ![Connection failure](https://cloud.githubusercontent.com/assets/144518/10450962/ba8bdc28-719d-11e5-8f90-5991ecd882ff.png)





