### PR TITLE
Show custom keyboard for entering URI.

### DIFF
--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -10,6 +10,7 @@
             android:key="schedule_url"
             android:title="@string/schedule_url"
             android:hint="https://yourhost/schedule.xml"
+            android:inputType="textUri"
             />
         <CheckBoxPreference
             android:key="alternative_highlight"


### PR DESCRIPTION
I customized the keyboard which is shown when the user enters an alternative schedule address.

### Generic keyboard

![keyboard-generic](https://cloud.githubusercontent.com/assets/144518/11879504/18d7ff96-a4fc-11e5-836d-09e063bf0766.png)

### Custom URI keyboard

![keyboard-uri](https://cloud.githubusercontent.com/assets/144518/11879508/1cd0f058-a4fc-11e5-826a-fcee9f013b2d.png)

