### PR TITLE
Support simple links without title.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanParser.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanParser.java
@@ -336,6 +336,9 @@ class parser extends AsyncTask<String, Void, Boolean> {
                                             String url = parser.getAttributeValue(null, "href");
                                             parser.next();
                                             String urlname = parser.getText();
+                                            if (url == null) {
+                                                url = urlname;
+                                            }
                                             if (!url.contains("://")) {
                                                 url = "http://" + url;
                                             }


### PR DESCRIPTION
+ Resolve NullPointerException caused when url is null.

---

Normally links are contained in *schedule.xml* as follows:

``` xml
<link href="https://example.com/path/to/page.html">My example</link>
```

Here is another case which was not handled yet:

``` xml
<link>https://example.com/path/to/page.html</link>
```