### PR TITLE
Hide individual views if event details are missing.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
@@ -6,6 +6,7 @@ import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
@@ -143,8 +144,7 @@ public class EventDetailFragment extends Fragment {
             // Title
 
             t = (TextView) view.findViewById(R.id.title);
-            t.setTypeface(boldCondensed);
-            t.setText(title);
+            setUpTextView(t, boldCondensed, title);
 
             // Subtitle
 
@@ -152,9 +152,7 @@ public class EventDetailFragment extends Fragment {
             if (TextUtils.isEmpty(subtitle)) {
                 t.setVisibility(View.GONE);
             } else {
-                t.setTypeface(light);
-                t.setText(subtitle);
-                t.setVisibility(View.VISIBLE);
+                setUpTextView(t, light, subtitle);
             }
 
             // Speakers
@@ -163,9 +161,7 @@ public class EventDetailFragment extends Fragment {
             if (TextUtils.isEmpty(spkr)) {
                 t.setVisibility(View.GONE);
             } else {
-                t.setTypeface(black);
-                t.setText(spkr);
-                t.setVisibility(View.VISIBLE);
+                setUpTextView(t, black, spkr);
             }
 
             // Abstract
@@ -175,11 +171,7 @@ public class EventDetailFragment extends Fragment {
                 t.setVisibility(View.GONE);
             } else {
                 abstractt = StringUtils.getHtmlLinkFromMarkdown(abstractt);
-                t.setTypeface(bold);
-                t.setText(Html.fromHtml(abstractt), TextView.BufferType.SPANNABLE);
-                t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
-                t.setMovementMethod(new LinkMovementMethod());
-                t.setVisibility(View.VISIBLE);
+                setUpHtmlTextView(t, bold, abstractt);
             }
 
             // Description
@@ -189,11 +181,7 @@ public class EventDetailFragment extends Fragment {
                 t.setVisibility(View.GONE);
             } else {
                 descr = StringUtils.getHtmlLinkFromMarkdown(descr);
-                t.setTypeface(regular);
-                t.setText(Html.fromHtml(descr), TextView.BufferType.SPANNABLE);
-                t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
-                t.setMovementMethod(new LinkMovementMethod());
-                t.setVisibility(View.VISIBLE);
+                setUpHtmlTextView(t, regular, descr);
             }
 
             // Links
@@ -205,15 +193,11 @@ public class EventDetailFragment extends Fragment {
                 t.setVisibility(View.GONE);
             } else {
                 l.setTypeface(bold);
-                t.setTypeface(regular);
                 MyApp.LogDebug(LOG_TAG, "show links");
                 l.setVisibility(View.VISIBLE);
-                t.setVisibility(View.VISIBLE);
                 links = links.replaceAll("\\),", ")<br>");
                 links = StringUtils.getHtmlLinkFromMarkdown(links);
-                t.setText(Html.fromHtml(links), TextView.BufferType.SPANNABLE);
-                t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
-                t.setMovementMethod(new LinkMovementMethod());
+                setUpHtmlTextView(t, regular, links);
             }
 
             // Event online
@@ -222,16 +206,32 @@ public class EventDetailFragment extends Fragment {
                     .findViewById(R.id.eventOnlineSection);
             eventOnlineSection.setTypeface(bold);
             final TextView eventOnlineLink = (TextView) view.findViewById(R.id.eventOnline);
-            eventOnlineLink.setTypeface(regular);
             final String eventUrl = FahrplanMisc.getEventUrl(activity, event_id);
             final String eventLink = "<a href=\"" + eventUrl + "\">" + eventUrl + "</a>";
-            eventOnlineLink.setText(Html.fromHtml(eventLink), TextView.BufferType.SPANNABLE);
-            eventOnlineLink.setMovementMethod(new LinkMovementMethod());
-            eventOnlineLink.setLinkTextColor(getResources().getColor(R.color.text_link_color));
+            setUpHtmlTextView(eventOnlineLink, regular, eventLink);
 
             activity.supportInvalidateOptionsMenu();
         }
         activity.setResult(FragmentActivity.RESULT_CANCELED);
+    }
+
+    private void setUpTextView(@NonNull TextView textView,
+                               @NonNull Typeface typeface,
+                               @NonNull String text) {
+        textView.setTypeface(typeface);
+        textView.setText(text);
+        textView.setVisibility(View.VISIBLE);
+    }
+
+
+    private void setUpHtmlTextView(@NonNull TextView textView,
+                                   @NonNull Typeface typeface,
+                                   @NonNull String text) {
+        textView.setTypeface(typeface);
+        textView.setText(Html.fromHtml(text), TextView.BufferType.SPANNABLE);
+        textView.setLinkTextColor(getResources().getColor(R.color.text_link_color));
+        textView.setMovementMethod(new LinkMovementMethod());
+        textView.setVisibility(View.VISIBLE);
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress;
 
 import android.content.Intent;
+import android.content.res.AssetManager;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Build;
@@ -110,18 +111,18 @@ public class EventDetailFragment extends Fragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        FragmentActivity activity = getActivity();
         if (hasArguments) {
-            boldCondensed = Typeface
-                    .createFromAsset(getActivity().getAssets(), "Roboto-BoldCondensed.ttf");
-            black = Typeface.createFromAsset(getActivity().getAssets(), "Roboto-Black.ttf");
-            light = Typeface.createFromAsset(getActivity().getAssets(), "Roboto-Light.ttf");
-            regular = Typeface
-                    .createFromAsset(getActivity().getAssets(), "Roboto-Regular.ttf");
-            bold = Typeface.createFromAsset(getActivity().getAssets(), "Roboto-Bold.ttf");
+            AssetManager assetManager = activity.getAssets();
+            boldCondensed = Typeface.createFromAsset(assetManager, "Roboto-BoldCondensed.ttf");
+            black = Typeface.createFromAsset(assetManager, "Roboto-Black.ttf");
+            light = Typeface.createFromAsset(assetManager, "Roboto-Light.ttf");
+            regular = Typeface.createFromAsset(assetManager, "Roboto-Regular.ttf");
+            bold = Typeface.createFromAsset(assetManager, "Roboto-Bold.ttf");
 
             locale = getResources().getConfiguration().locale;
 
-            FahrplanFragment.loadLectureList(getActivity(), day, false);
+            FahrplanFragment.loadLectureList(activity, day, false);
             lecture = eventid2Lecture(event_id);
 
             TextView t;
@@ -224,15 +225,15 @@ public class EventDetailFragment extends Fragment {
             eventOnlineSection.setTypeface(bold);
             final TextView eventOnlineLink = (TextView) view.findViewById(R.id.eventOnline);
             eventOnlineLink.setTypeface(regular);
-            final String eventUrl = FahrplanMisc.getEventUrl(getActivity(), event_id);
+            final String eventUrl = FahrplanMisc.getEventUrl(activity, event_id);
             final String eventLink = "<a href=\"" + eventUrl + "\">" + eventUrl + "</a>";
             eventOnlineLink.setText(Html.fromHtml(eventLink), TextView.BufferType.SPANNABLE);
             eventOnlineLink.setMovementMethod(new LinkMovementMethod());
             eventOnlineLink.setLinkTextColor(getResources().getColor(R.color.text_link_color));
 
-            getActivity().supportInvalidateOptionsMenu();
+            activity.supportInvalidateOptionsMenu();
         }
-        getActivity().setResult(FragmentActivity.RESULT_CANCELED);
+        activity.setResult(FragmentActivity.RESULT_CANCELED);
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
@@ -9,6 +9,7 @@ import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.text.Html;
+import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -138,42 +139,74 @@ public class EventDetailFragment extends Fragment {
                 t.setText("ID: " + event_id);
             }
 
+            // Title
+
             t = (TextView) view.findViewById(R.id.title);
             t.setTypeface(boldCondensed);
             t.setText(title);
 
+            // Subtitle
+
             t = (TextView) view.findViewById(R.id.subtitle);
-            t.setText(subtitle);
-            t.setTypeface(light);
-            if (subtitle.length() == 0) {
+            if (TextUtils.isEmpty(subtitle)) {
                 t.setVisibility(View.GONE);
+            } else {
+                t.setTypeface(light);
+                t.setText(subtitle);
+                t.setVisibility(View.VISIBLE);
             }
 
+            // Speakers
+
             t = (TextView) view.findViewById(R.id.speakers);
-            t.setTypeface(black);
-            t.setText(spkr);
+            if (TextUtils.isEmpty(spkr)) {
+                t.setVisibility(View.GONE);
+            } else {
+                t.setTypeface(black);
+                t.setText(spkr);
+                t.setVisibility(View.VISIBLE);
+            }
+
+            // Abstract
 
             t = (TextView) view.findViewById(R.id.abstractt);
-            t.setTypeface(bold);
-            abstractt = abstractt
-                    .replaceAll("\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
-            t.setText(Html.fromHtml(abstractt), TextView.BufferType.SPANNABLE);
-            t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
-            t.setMovementMethod(new LinkMovementMethod());
+            if (TextUtils.isEmpty(abstractt)) {
+                t.setVisibility(View.GONE);
+            } else {
+                abstractt = abstractt.replaceAll(
+                        "\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
+                t.setTypeface(bold);
+                t.setText(Html.fromHtml(abstractt), TextView.BufferType.SPANNABLE);
+                t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
+                t.setMovementMethod(new LinkMovementMethod());
+                t.setVisibility(View.VISIBLE);
+            }
+
+            // Description
 
             t = (TextView) view.findViewById(R.id.description);
-            t.setTypeface(regular);
-            descr = descr.replaceAll("\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
-            t.setText(Html.fromHtml(descr), TextView.BufferType.SPANNABLE);
-            t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
-            t.setMovementMethod(new LinkMovementMethod());
+            if (TextUtils.isEmpty(descr)) {
+                t.setVisibility(View.GONE);
+            } else {
+                descr = descr.replaceAll(
+                        "\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
+                t.setTypeface(regular);
+                t.setText(Html.fromHtml(descr), TextView.BufferType.SPANNABLE);
+                t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
+                t.setMovementMethod(new LinkMovementMethod());
+                t.setVisibility(View.VISIBLE);
+            }
+
+            // Links
 
             TextView l = (TextView) view.findViewById(R.id.linksSection);
-            l.setTypeface(bold);
             t = (TextView) view.findViewById(R.id.links);
-            t.setTypeface(regular);
-
-            if (links.length() > 0) {
+            if (TextUtils.isEmpty(links)) {
+                l.setVisibility(View.GONE);
+                t.setVisibility(View.GONE);
+            } else {
+                l.setTypeface(bold);
+                t.setTypeface(regular);
                 MyApp.LogDebug(LOG_TAG, "show links");
                 l.setVisibility(View.VISIBLE);
                 t.setVisibility(View.VISIBLE);
@@ -182,10 +215,9 @@ public class EventDetailFragment extends Fragment {
                 t.setText(Html.fromHtml(links), TextView.BufferType.SPANNABLE);
                 t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
                 t.setMovementMethod(new LinkMovementMethod());
-            } else {
-                l.setVisibility(View.GONE);
-                t.setVisibility(View.GONE);
             }
+
+            // Event online
 
             final TextView eventOnlineSection = (TextView) view
                     .findViewById(R.id.eventOnlineSection);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/EventDetailFragment.java
@@ -174,8 +174,7 @@ public class EventDetailFragment extends Fragment {
             if (TextUtils.isEmpty(abstractt)) {
                 t.setVisibility(View.GONE);
             } else {
-                abstractt = abstractt.replaceAll(
-                        "\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
+                abstractt = StringUtils.getHtmlLinkFromMarkdown(abstractt);
                 t.setTypeface(bold);
                 t.setText(Html.fromHtml(abstractt), TextView.BufferType.SPANNABLE);
                 t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
@@ -189,8 +188,7 @@ public class EventDetailFragment extends Fragment {
             if (TextUtils.isEmpty(descr)) {
                 t.setVisibility(View.GONE);
             } else {
-                descr = descr.replaceAll(
-                        "\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
+                descr = StringUtils.getHtmlLinkFromMarkdown(descr);
                 t.setTypeface(regular);
                 t.setText(Html.fromHtml(descr), TextView.BufferType.SPANNABLE);
                 t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
@@ -212,7 +210,7 @@ public class EventDetailFragment extends Fragment {
                 l.setVisibility(View.VISIBLE);
                 t.setVisibility(View.VISIBLE);
                 links = links.replaceAll("\\),", ")<br>");
-                links = links.replaceAll("\\[(.*?)\\]\\(([^ \\)]+).*?\\)", "<a href=\"$2\">$1</a>");
+                links = StringUtils.getHtmlLinkFromMarkdown(links);
                 t.setText(Html.fromHtml(links), TextView.BufferType.SPANNABLE);
                 t.setLinkTextColor(getResources().getColor(R.color.text_link_color));
                 t.setMovementMethod(new LinkMovementMethod());

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StringUtils.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/StringUtils.java
@@ -1,0 +1,15 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+import android.support.annotation.NonNull;
+
+public abstract class StringUtils {
+
+    public static final String MARKDOWN_LINK_REGEX = "\\[(.*?)\\]\\(([^ \\)]+).*?\\)";
+
+    public static final String HTML_LINK_TEMPLATE = "<a href=\"$2\">$1</a>";
+
+    public static String getHtmlLinkFromMarkdown(@NonNull String markdown) {
+        return markdown.replaceAll(MARKDOWN_LINK_REGEX, HTML_LINK_TEMPLATE);
+    }
+
+}

--- a/app/src/test/java/StringUtilsTests.java
+++ b/app/src/test/java/StringUtilsTests.java
@@ -1,0 +1,28 @@
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import nerd.tuxmobil.fahrplan.congress.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class StringUtilsTests {
+
+    @Test
+    public void getHtmlLinkFromMarkdownWithSingleLinks() {
+        String markdown = "[Chaos Computer Club](https://www.ccc.de)";
+        String htmlLink = "<a href=\"https://www.ccc.de\">Chaos Computer Club</a>";
+        assertThat(StringUtils.getHtmlLinkFromMarkdown(markdown)).isEqualTo(htmlLink);
+    }
+
+    @Test
+    public void getHtmlLinkFromMarkdownWithMultipleLinks() {
+        String markdown = "[Chaos Computer Club](https://www.ccc.de)<br>" +
+                "[Bundestag](https://www.bundestag.de)";
+        String htmlLink = "<a href=\"https://www.ccc.de\">Chaos Computer Club</a><br>" +
+                "<a href=\"https://www.bundestag.de\">Bundestag</a>";
+        assertThat(StringUtils.getHtmlLinkFromMarkdown(markdown)).isEqualTo(htmlLink);
+    }
+
+}


### PR DESCRIPTION
I noticed that the content for workshop events is limited to a subset of the fields. Therefore, I removed unneeded whitespace.
### A random example - Before and after

![before](https://cloud.githubusercontent.com/assets/144518/12039489/358a30c8-ae61-11e5-9d20-8e16a909a999.png) ![after](https://cloud.githubusercontent.com/assets/144518/12039488/356911ae-ae61-11e5-907e-d79342a14d09.png)
