### PR TITLE
Custom window background

### DIFF
--- a/app/src/camp2015/res/values/colors.xml
+++ b/app/src/camp2015/res/values/colors.xml
@@ -5,7 +5,7 @@
     <color name="colorActionBar">#6C822D</color>
     <color name="colorPrimaryDark">#4D5E1F</color>
     <color name="colorAccent">#92B82A</color>
-    <color name="fahrplan_background">#1a1a1a</color>
+    <color name="windowBackground">#1a1a1a</color>
     <color name="text_link_color">#48571E</color>
     <color name="multi_choice_background">#402424b3</color>
     <color name="text_link_color_dark">#8FAD3C</color>

--- a/app/src/ccc31c3/res/values/colors.xml
+++ b/app/src/ccc31c3/res/values/colors.xml
@@ -5,7 +5,7 @@
     <color name="colorActionBar">#ff44426e</color>
     <color name="colorPrimaryDark">#ff272640</color>
     <color name="colorAccent">#906de1</color>
-    <color name="fahrplan_background">#1a1a1a</color>
+    <color name="windowBackground">#1a1a1a</color>
     <color name="text_link_color">#ff6464b3</color>
     <color name="multi_choice_background">#402424b3</color>
     <color name="text_link_color_dark">#ff7979d1</color>

--- a/app/src/ccc32c3/res/values/colors.xml
+++ b/app/src/ccc32c3/res/values/colors.xml
@@ -5,7 +5,7 @@
     <color name="colorActionBar">#383838</color>
     <color name="colorPrimaryDark">#202020</color>
     <color name="colorAccent">#f19224</color>
-    <color name="fahrplan_background">#1a1a1a</color>
+    <color name="windowBackground">#1a1a1a</color>
     <color name="text_link_color">#dc851f</color>
     <color name="multi_choice_background">#40f19224</color>
     <color name="text_link_color_dark">#ffdc851f</color>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AboutDialog.java
@@ -20,7 +20,7 @@ public class AboutDialog extends DialogFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setStyle(DialogFragment.STYLE_NO_TITLE, getTheme());
+        setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Dialog);
     }
 
     @Override

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -59,8 +59,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:fadingEdge="none"
-                    android:scrollbars="none"
-                    android:background="@color/fahrplan_background">
+                    android:scrollbars="none">
 
                 <LinearLayout
                         android:id="@+id/scrollContainer"

--- a/app/src/main/res/layout/alarms.xml
+++ b/app/src/main/res/layout/alarms.xml
@@ -6,7 +6,6 @@
         android:layout_height="fill_parent"
         android:orientation="vertical"
         android:gravity="center"
-        android:background="@color/fahrplan_background"
         tools:background="@android:color/holo_red_light">
 
     <ListView

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -62,15 +62,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:fadingEdge="none"
-                    android:scrollbars="none"
-                    android:background="@color/fahrplan_background">
+                    android:scrollbars="none">
 
                 <LinearLayout
                         android:id="@+id/scrollContainer"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        android:background="@color/fahrplan_background"
                         android:orientation="horizontal">
 
                 </LinearLayout>

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -63,15 +63,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:fadingEdge="none"
-                    android:scrollbars="none"
-                    android:background="@color/fahrplan_background">
+                    android:scrollbars="none">
 
                 <LinearLayout
                         android:id="@+id/scrollContainer"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        android:background="@color/fahrplan_background"
                         android:orientation="horizontal">
 
                 </LinearLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -4,7 +4,6 @@
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_height="match_parent"
               android:layout_width="match_parent"
-              android:background="@color/fahrplan_background"
               >
 
     <android.support.v7.widget.Toolbar

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <color name="fahrplan_background">#003339</color>
+    <color name="windowBackground">#003339</color>
     <color name="text_link_color">#33b5e5</color>
     <color name="lightgray">#505050</color>
     <color name="alarm_list_icon_default_fill_color">#ddd</color>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -53,6 +53,11 @@
         <item name="android:windowBackground">@color/windowBackground</item>
     </style>
 
+    <style name="Dialog" parent="Theme.AppCompat.Dialog">
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
+        <item name="android:windowBackground">@color/windowBackground</item>
+    </style>
+
     <style name="AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorAccent">@color/alert_dialog_button_text</item>
         <item name="android:textColor">@color/alert_dialog_title</item>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -33,6 +33,7 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeBackground">@color/colorPrimary</item>
         <item name="alertDialogTheme">@style/AlertDialog</item>
+        <item name="android:windowBackground">@color/windowBackground</item>
     </style>
 
     <style name="Theme.Congress.NoActionBar" parent="Theme.AppCompat.NoActionBar">
@@ -49,12 +50,14 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeBackground">@color/colorPrimary</item>
         <item name="alertDialogTheme">@style/AlertDialog</item>
+        <item name="android:windowBackground">@color/windowBackground</item>
     </style>
 
     <style name="AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorAccent">@color/alert_dialog_button_text</item>
         <item name="android:textColor">@color/alert_dialog_title</item>
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
+        <item name="android:windowBackground">@color/windowBackground</item>
     </style>
 
     <style name="MyActionDropDownStyle" parent="Widget.AppCompat.Spinner.DropDown.ActionBar">


### PR DESCRIPTION
This change encourages to use the framework attribute `android:windowBackground` within the central styles definition. Further, it allows to customize the background color of the about dialog. 
