### PR TITLE
Alarm updates: Conference start & end time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'com.squareup.assertj:assertj-android:1.1.1'
     testCompile 'com.android.support:support-annotations:23.1.1'
+    testCompile 'org.mockito:mockito-core:2.0.0-beta.117'
 
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdater.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdater.java
@@ -1,0 +1,66 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+import android.app.AlarmManager;
+import android.support.annotation.NonNull;
+
+public class AlarmUpdater {
+
+    interface OnAlarmUpdateListener {
+
+        void onCancelAlarm();
+
+        void onRescheduleAlarm(long interval, long nextFetch);
+
+        void onRescheduleInitialAlarm(long interval, long nextFetch);
+
+    }
+
+    private final long firstDayStartTime;
+
+    private final long lastDayEndTime;
+
+    private final OnAlarmUpdateListener listener;
+
+    public AlarmUpdater(long firstDayStartTime, long lastDayEndTime,
+                        @NonNull OnAlarmUpdateListener listener) {
+        this.firstDayStartTime = firstDayStartTime;
+        this.lastDayEndTime = lastDayEndTime;
+        this.listener = listener;
+    }
+
+    public long calculateInterval(long time, boolean initial) {
+        long interval;
+        long nextFetch;
+
+        long TWO_HOURS = 2 * AlarmManager.INTERVAL_HOUR;
+        long ONE_DAY = AlarmManager.INTERVAL_DAY;
+
+        if ((time >= firstDayStartTime) && (time < lastDayEndTime)) {
+            interval = TWO_HOURS;
+            nextFetch = time + interval;
+        } else if (time >= lastDayEndTime) {
+            listener.onCancelAlarm();
+            return 0;
+        } else {
+            interval = ONE_DAY;
+            nextFetch = time + interval;
+        }
+
+        long shiftedTime = time + ONE_DAY;
+        if ((time < firstDayStartTime) && (shiftedTime >= firstDayStartTime)) {
+            interval = TWO_HOURS;
+            nextFetch = firstDayStartTime;
+            if (!initial) {
+                listener.onCancelAlarm();
+                listener.onRescheduleAlarm(interval, nextFetch);
+            }
+        }
+
+        if (initial) {
+            listener.onCancelAlarm();
+            listener.onRescheduleInitialAlarm(interval, nextFetch);
+        }
+        return interval;
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdater.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdater.java
@@ -15,16 +15,13 @@ public class AlarmUpdater {
 
     }
 
-    private final long firstDayStartTime;
-
-    private final long lastDayEndTime;
+    private final ConferenceTimeFrame conference;
 
     private final OnAlarmUpdateListener listener;
 
-    public AlarmUpdater(long firstDayStartTime, long lastDayEndTime,
+    public AlarmUpdater(@NonNull ConferenceTimeFrame conferenceTimeFrame,
                         @NonNull OnAlarmUpdateListener listener) {
-        this.firstDayStartTime = firstDayStartTime;
-        this.lastDayEndTime = lastDayEndTime;
+        this.conference = conferenceTimeFrame;
         this.listener = listener;
     }
 
@@ -35,10 +32,10 @@ public class AlarmUpdater {
         long TWO_HOURS = 2 * AlarmManager.INTERVAL_HOUR;
         long ONE_DAY = AlarmManager.INTERVAL_DAY;
 
-        if ((time >= firstDayStartTime) && (time < lastDayEndTime)) {
+        if (conference.contains(time)) {
             interval = TWO_HOURS;
             nextFetch = time + interval;
-        } else if (time >= lastDayEndTime) {
+        } else if (conference.endsBefore(time)) {
             listener.onCancelAlarm();
             return 0;
         } else {
@@ -47,9 +44,9 @@ public class AlarmUpdater {
         }
 
         long shiftedTime = time + ONE_DAY;
-        if ((time < firstDayStartTime) && (shiftedTime >= firstDayStartTime)) {
+        if (conference.startsAfter(time) && conference.startsAtOrBefore(shiftedTime)) {
             interval = TWO_HOURS;
-            nextFetch = firstDayStartTime;
+            nextFetch = conference.getFirstDayStartTime();
             if (!initial) {
                 listener.onCancelAlarm();
                 listener.onRescheduleAlarm(interval, nextFetch);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConferenceTimeFrame.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/ConferenceTimeFrame.java
@@ -1,0 +1,39 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+public class ConferenceTimeFrame {
+
+    private final long firstDayStartTime;
+
+    private final long lastDayEndTime;
+
+    public ConferenceTimeFrame(long firstDayStartTime, long lastDayEndTime) {
+        this.firstDayStartTime = firstDayStartTime;
+        this.lastDayEndTime = lastDayEndTime;
+    }
+
+    public long getFirstDayStartTime() {
+        return firstDayStartTime;
+    }
+
+    public boolean contains(long time) {
+        return startsAtOrBefore(time) && (time < lastDayEndTime);
+    }
+
+    public boolean endsBefore(long time) {
+        return time >= lastDayEndTime;
+    }
+
+    public boolean startsAfter(long time) {
+        return time < firstDayStartTime;
+    }
+
+    public boolean startsAtOrBefore(long time) {
+        return time >= firstDayStartTime;
+    }
+
+    @Override
+    public String toString() {
+        return "firstDayStartTime = " + firstDayStartTime + ", lastDayEndTime = " + lastDayEndTime;
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanMisc.java
@@ -404,7 +404,7 @@ public class FahrplanMisc {
         t.setToNow();
         final long now = t.toMillis(true);
 
-        AlarmUpdater alarmUpdater = new AlarmUpdater(MyApp.first_day_start, MyApp.last_day_end,
+        AlarmUpdater alarmUpdater = new AlarmUpdater(MyApp.conferenceTimeFrame,
                 new AlarmUpdater.OnAlarmUpdateListener() {
 
                     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/FahrplanMisc.java
@@ -380,58 +380,6 @@ public class FahrplanMisc {
         }
     }
 
-    public static long setUpdateAlarm(Context context, boolean initial) {
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-
-        Intent alarmintent = new Intent(context, AlarmReceiver.class);
-        alarmintent.setAction(AlarmReceiver.ALARM_UPDATE);
-
-        PendingIntent pendingintent = PendingIntent.getBroadcast(context, 0, alarmintent, 0);
-
-        MyApp.LogDebug(LOG_TAG, "set update alarm");
-        long next_fetch;
-        long interval;
-        Time t = new Time();
-        t.setToNow();
-        long now = t.toMillis(true);
-
-        if ((now >= MyApp.first_day_start) && (now < MyApp.last_day_end)) {
-            interval = 2 * AlarmManager.INTERVAL_HOUR;
-            next_fetch = now + interval;
-        } else if (now >= MyApp.last_day_end) {
-            MyApp.LogDebug(LOG_TAG, "cancel alarm post congress");
-            alarmManager.cancel(pendingintent);
-            return 0;
-        } else {
-            interval = AlarmManager.INTERVAL_DAY;
-            next_fetch = now + interval;
-        }
-
-        if ((now < MyApp.first_day_start) && ((now + AlarmManager.INTERVAL_DAY)
-                >= MyApp.first_day_start)) {
-            next_fetch = MyApp.first_day_start;
-            interval = 2 * AlarmManager.INTERVAL_HOUR;
-            if (!initial) {
-                MyApp.LogDebug(LOG_TAG,
-                        "update alarm to interval " + interval + ", next in " + (next_fetch - now));
-                alarmManager.cancel(pendingintent);
-                alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, next_fetch, interval,
-                        pendingintent);
-            }
-        }
-
-        if (initial) {
-            MyApp.LogDebug(LOG_TAG,
-                    "set initial alarm to interval " + interval + ", next in " + (next_fetch
-                            - now));
-            alarmManager.cancel(pendingintent);
-            alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, next_fetch, interval,
-                    pendingintent);
-        }
-
-        return interval;
-    }
-
     public static void clearUpdateAlarm(Context context) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
 
@@ -443,6 +391,45 @@ public class FahrplanMisc {
         MyApp.LogDebug(LOG_TAG, "clear update alarm");
 
         alarmManager.cancel(pendingintent);
+    }
+
+    public static long setUpdateAlarm(Context context, boolean initial) {
+        final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        Intent alarmIntent = new Intent(context, AlarmReceiver.class);
+        alarmIntent.setAction(AlarmReceiver.ALARM_UPDATE);
+        final PendingIntent pendingintent = PendingIntent.getBroadcast(context, 0, alarmIntent, 0);
+
+        MyApp.LogDebug(LOG_TAG, "set update alarm");
+        Time t = new Time();
+        t.setToNow();
+        final long now = t.toMillis(true);
+
+        AlarmUpdater alarmUpdater = new AlarmUpdater(MyApp.first_day_start, MyApp.last_day_end,
+                new AlarmUpdater.OnAlarmUpdateListener() {
+
+                    @Override
+                    public void onCancelAlarm() {
+                        MyApp.LogDebug(LOG_TAG, "cancel alarm post congress");
+                        alarmManager.cancel(pendingintent);
+                    }
+
+                    @Override
+                    public void onRescheduleAlarm(long interval, long nextFetch) {
+                        MyApp.LogDebug(LOG_TAG, "update alarm to interval " + interval +
+                                ", next in " + (nextFetch - now));
+                        alarmManager.setInexactRepeating(
+                                AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingintent);
+                    }
+
+                    @Override
+                    public void onRescheduleInitialAlarm(long interval, long nextFetch) {
+                        MyApp.LogDebug(LOG_TAG, "set initial alarm to interval " + interval +
+                                ", next in " + (nextFetch - now));
+                        alarmManager.setInexactRepeating(
+                                AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingintent);
+                    }
+                });
+        return alarmUpdater.calculateInterval(now, initial);
     }
 
     public static LectureList loadLecturesForAllDays(Context context) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
@@ -32,15 +32,18 @@ public class MyApp extends Application {
 
     public static FahrplanParser parser = null;
 
-    public static long first_day_start = getMilliseconds("Europe/Paris",
+    private static long first_day_start = getMilliseconds("Europe/Paris",
             BuildConfig.SCHEDULE_FIRST_DAY_START_YEAR,
             BuildConfig.SCHEDULE_FIRST_DAY_START_MONTH,
             BuildConfig.SCHEDULE_FIRST_DAY_START_DAY);
 
-    public static long last_day_end = getMilliseconds("Europe/Paris",
+    private static long last_day_end = getMilliseconds("Europe/Paris",
             BuildConfig.SCHEDULE_LAST_DAY_END_YEAR,
             BuildConfig.SCHEDULE_LAST_DAY_END_MONTH,
             BuildConfig.SCHEDULE_LAST_DAY_END_DAY);
+
+    public static final ConferenceTimeFrame conferenceTimeFrame =
+            new ConferenceTimeFrame(first_day_start, last_day_end);
 
     public static int room_count = 0;
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdaterTest.java
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdaterTest.java
@@ -20,6 +20,9 @@ public class AlarmUpdaterTest {
     // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
     final long LAST_DAY_END_TIME = 1451516400000L;
 
+    final ConferenceTimeFrame conferenceTimeFrame =
+            new ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME);
+
     final long NEVER_USED = -1;
 
     AlarmUpdater alarmUpdater;
@@ -29,7 +32,7 @@ public class AlarmUpdaterTest {
 
     @Before
     public void setUp() throws Exception {
-        alarmUpdater = new AlarmUpdater(FIRST_DAY_START_TIME, LAST_DAY_END_TIME, mockListener);
+        alarmUpdater = new AlarmUpdater(conferenceTimeFrame, mockListener);
     }
 
     // Start <= Time < End

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdaterTest.java
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/AlarmUpdaterTest.java
@@ -1,0 +1,146 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+
+@RunWith(JUnit4.class)
+public class AlarmUpdaterTest {
+
+    // 2015-12-27T00:00:00+0100, in seconds: 1451170800000
+    final long FIRST_DAY_START_TIME = 1451170800000L;
+
+    // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+    final long LAST_DAY_END_TIME = 1451516400000L;
+
+    final long NEVER_USED = -1;
+
+    AlarmUpdater alarmUpdater;
+
+    AlarmUpdater.OnAlarmUpdateListener mockListener =
+            mock(AlarmUpdater.OnAlarmUpdateListener.class);
+
+    @Before
+    public void setUp() throws Exception {
+        alarmUpdater = new AlarmUpdater(FIRST_DAY_START_TIME, LAST_DAY_END_TIME, mockListener);
+    }
+
+    // Start <= Time < End
+
+    @Test
+    public void calculateIntervalWithTimeOfFirstDay() throws Exception {
+        // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
+        long interval = alarmUpdater.calculateInterval(1451212200000L, false);
+        assertThat(interval).isEqualTo(7200000L);
+        verify(mockListener, never()).onCancelAlarm();
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    @Test
+    public void calculateIntervalWithTimeOfFirstDayInitial() throws Exception {
+        // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
+        long interval = alarmUpdater.calculateInterval(1451212200000L, true);
+        assertThat(interval).isEqualTo(7200000L);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451212200000L + 7200000L);
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    // Time == End
+
+    @Test
+    public void calculateIntervalWithTimeOfLastDayEndTime() throws Exception {
+        // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+        long interval = alarmUpdater.calculateInterval(1451516400000L, false);
+        assertThat(interval).isEqualTo(0);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    @Test
+    public void calculateIntervalWithTimeOfLastDayEndTimeInitial() throws Exception {
+        // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+        long interval = alarmUpdater.calculateInterval(1451516400000L, true);
+        assertThat(interval).isEqualTo(0);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    // Time < Start, diff == 1 second
+
+    @Test
+    public void calculateIntervalWithTimeOneSecondBeforeFirstDay() throws Exception {
+        // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
+        long interval = alarmUpdater.calculateInterval(1451170799000L, false);
+        assertThat(interval).isEqualTo(7200000L);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener).onRescheduleAlarm(7200000L, 1451170800000L);
+        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    @Test
+    public void calculateIntervalWithTimeOneSecondBeforeFirstDayInitial() throws Exception {
+        // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
+        long interval = alarmUpdater.calculateInterval(1451170799000L, true);
+        assertThat(interval).isEqualTo(7200000L);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L);
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    // Time < Start, diff == 1 day
+
+    @Test
+    public void calculateIntervalWithTimeOneDayBeforeFirstDay() throws Exception {
+        // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
+        long interval = alarmUpdater.calculateInterval(1451084400000L, false);
+        assertThat(interval).isEqualTo(7200000L);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener).onRescheduleAlarm(7200000L, 1451170800000L);
+        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    @Test
+    public void calculateIntervalWithTimeOneDayBeforeFirstDayInitial() throws Exception {
+        // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
+        long interval = alarmUpdater.calculateInterval(1451084400000L, true);
+        assertThat(interval).isEqualTo(7200000L);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L);
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    // Time < Start, diff > 1 day
+
+    @Test
+    public void calculateIntervalWithTimeMoreThanOneDayBeforeFirstDay() throws Exception {
+        // 2015-12-25T23:59:59+0100, in seconds: 1451084399000
+        long interval = alarmUpdater.calculateInterval(1451084399000L, false);
+        assertThat(interval).isEqualTo(86400000L);
+        // TODO Is this behavior intended?
+        verify(mockListener, never()).onCancelAlarm();
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+    }
+
+    @Test
+    public void calculateIntervalWithTimeMoreThanOneDayBeforeFirstDayInitial() throws Exception {
+        // 2015-12-25T23:59:59+0100, in seconds: 1451084399000
+        long interval = alarmUpdater.calculateInterval(1451084399000L, true);
+        assertThat(interval).isEqualTo(86400000L);
+        verify(mockListener).onCancelAlarm();
+        verify(mockListener).onRescheduleInitialAlarm(86400000L, 1451084399000L + 86400000L);
+        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/ConferenceTimeFrameTest.java
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/ConferenceTimeFrameTest.java
@@ -1,0 +1,83 @@
+package nerd.tuxmobil.fahrplan.congress;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class ConferenceTimeFrameTest {
+
+    // 2015-12-27T00:00:00+0100, in seconds: 1451170800000
+    final long FIRST_DAY_START_TIME = 1451170800000L;
+
+    // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+    final long LAST_DAY_END_TIME = 1451516400000L;
+
+    private ConferenceTimeFrame conference;
+
+    @Before
+    public void setUp() throws Exception {
+        conference = new ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME);
+    }
+
+    @Test
+    public void getFirstDayStart() throws Exception {
+        assertThat(conference.getFirstDayStartTime()).isEqualTo(FIRST_DAY_START_TIME);
+    }
+
+    @Test
+    public void containsWithTimeWithFirstDayEvent() throws Exception {
+        // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
+        assertThat(conference.contains(1451212200000L)).isTrue();
+    }
+
+    @Test
+    public void containsWithOneSecondBeforeFirstDay() throws Exception {
+        // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
+        assertThat(conference.contains(1451170799000L)).isFalse();
+    }
+
+    @Test
+    public void containsWithTimeOfLastDay() throws Exception {
+        assertThat(conference.contains(LAST_DAY_END_TIME)).isFalse();
+    }
+
+    @Test
+    public void endsBeforeWithTimeOfLastDay() throws Exception {
+        assertThat(conference.endsBefore(LAST_DAY_END_TIME)).isTrue();
+    }
+
+    @Test
+    public void endsBeforeWithTimeBeforeLastDay() throws Exception {
+        assertThat(conference.endsBefore(LAST_DAY_END_TIME - 1)).isFalse();
+    }
+
+    @Test
+    public void startsAfterWithTimeOfFirstDay() throws Exception {
+        assertThat(conference.startsAfter(FIRST_DAY_START_TIME)).isFalse();
+    }
+
+    @Test
+    public void startsAfterWithTimeBeforeFirstDay() throws Exception {
+        assertThat(conference.startsAfter(FIRST_DAY_START_TIME - 1)).isTrue();
+    }
+
+    @Test
+    public void startsAtOrBeforeWithTimeOfFirstDay() throws Exception {
+        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME)).isTrue();
+    }
+
+    @Test
+    public void startsAtOrBeforeWithTimeAfterFirstDay() throws Exception {
+        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME + 1)).isTrue();
+    }
+
+    @Test
+    public void startsAtOrBeforeWithTimeBeforeFirstDay() throws Exception {
+        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME - 1)).isFalse();
+    }
+
+}


### PR DESCRIPTION
I refactored the part where **alarm times** are **updated** since I found the calculation hard to understand.
1. I moved the logic part into its own `AlarmUpdater` class to allow unit testing.
2. I extracted the time comparison into the `ConferenceTimeFrame` class to improve readability. This also comes with unit tests.

@tuxmobil Please check the tests and the `TODO` I left there.
