### PR TITLE
Set default background color of time column to black.

### DIFF
--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -51,7 +51,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:orientation="vertical"
-                    android:background="#ffaaaaaa">
+                    android:background="@color/time_column_background">
             </LinearLayout>
 
             <nerd.tuxmobil.fahrplan.congress.HorizontalSnapScrollView

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -52,7 +52,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:layout_weight="0"
-                    android:background="#ffaaaaaa"
+                    android:background="@color/time_column_background"
                     android:orientation="vertical">
 
             </LinearLayout>

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -53,7 +53,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:layout_weight="0"
-                    android:background="#ffaaaaaa"
+                    android:background="@color/time_column_background"
                     android:orientation="vertical">
 
             </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="alarm_list_icon_default_fill_color">#ddd</color>
     <color name="alarm_list_icon_default_stroke_color">#003339</color>
     <color name="alarm_list_icon_text_color">#000000</color>
+    <color name="time_column_background">#000000</color>
     <color name="lecture_background">#ffffff</color>
     <color name="lecture_detailbar_background">#eee</color>
     <color name="lecture_detailbar_text">#999</color>


### PR DESCRIPTION
+ Otherwise you'll see an ugly white bar where time 'does not exist'
  (after lecture end etc.)
+ Cherry-picked from Andreas Schildbach, 33C3 app.

See https://github.com/ligi/CampFahrplan/commit/6530695b7e7091854d24be4622a2b62a42e499a0

/cc @schildbach