### PR TITLE
Prevent duration text to wrap when track name pushes in place.

### DIFF
--- a/app/src/main/res/layout/lecture_change_row.xml
+++ b/app/src/main/res/layout/lecture_change_row.xml
@@ -99,14 +99,13 @@
             tools:background="@android:color/holo_red_light"/>
 
         <TextView
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="@style/ScheduleListSecondary"
             tools:text="@string/placeholder_event_duration"
             android:id="@+id/duration"
             android:layout_marginRight="8dp"
             android:layout_marginEnd="8dp"
-            android:layout_weight="1"
             tools:background="@android:color/holo_blue_light"/>
 
         <TextView


### PR DESCRIPTION
The _duration_ text wraps into multiple lines when a long _track_ text pushes from the right. See screenshot:

![lecture-changes](https://cloud.githubusercontent.com/assets/144518/22406343/0778db1a-e652-11e6-95af-3f7c7883e076.png)

Originally committed by @ligi. Cherry-picked from [33C3 app](https://github.com/ligi/CampFahrplan/commit/c04d0dfb704e46e41ed8d0a6991cb938d384fd25).